### PR TITLE
API: Replace external `usize` with `u32`

### DIFF
--- a/src/demo.rs
+++ b/src/demo.rs
@@ -29,7 +29,7 @@ pub fn sample_text(fb: &mut FrBuf) {
     paint_str(fb, clip, c, GlyphStyle::Regular, wrap, true, crate::xor_char);
     // Demonstrate messing with the clip region and cursor:
     // 1. Convenience function to make a new cursor
-    let c = &mut Cursor::new(c.pt.x, c.pt.y, c.line_height);
+    let c = &mut Cursor::new(c.pt.x as _, c.pt.y as _, c.line_height as _);
     // 2. Reduce the ClipRect to a small-ish box at the bottom of the screen
     //    with big margins on its left and right sides
     clip.min.y = c.pt.y + 12;
@@ -38,7 +38,7 @@ pub fn sample_text(fb: &mut FrBuf) {
     clip.max.x -= 40;
     // 3. Convenience function to make a new ClipRect with min/max auto-correct
     //    Note: fn def is `new(min_x: usize, min_y: usize, max_x: usize, max_y: usize)`
-    let clip = ClipRect::new(clip.max.x, clip.min.y, clip.min.x, clip.max.y);
+    let clip = ClipRect::new(clip.max.x as _, clip.min.y as _, clip.min.x as _, clip.max.y as _);
     // Blit the string
     paint_str(fb, clip, c, GlyphStyle::Small, wrap, true, crate::xor_char);
 }

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -18,16 +18,16 @@ use core::fmt;
 
 /// Holds header data for a font glyph
 pub struct GlyphHeader {
-    pub w: usize,
-    pub h: usize,
-    pub y_offset: usize,
+    pub w: u32,
+    pub h: u32,
+    pub y_offset: u32,
 }
 impl GlyphHeader {
     /// Unpack glyph header of format: (w:u8)<<16 | (h:u8)<<8 | yOffset:u8
     pub fn new(header: u32) -> GlyphHeader {
-        let w = ((header << 8) >> 24) as usize;
-        let h = ((header << 16) >> 24) as usize;
-        let y_offset = (header & 0x000000ff) as usize;
+        let w = ((header << 8) >> 24) as u32;
+        let h = ((header << 16) >> 24) as u32;
+        let y_offset = (header & 0x000000ff) as u32;
         GlyphHeader { w, h, y_offset }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub const fn new_fr_buf() -> FrBuf {
 }
 
 /// Point specifies a pixel coordinate
+#[repr(C)]
 #[derive(Copy, Clone, Debug, PartialEq)]
 pub struct Pt {
     pub x: u32,
@@ -32,6 +33,7 @@ pub struct Pt {
 /// be different heights. Line_height is for keeping track of the tallest
 /// character that has been drawn so far on the current line.
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
 pub struct Cursor {
     pub pt: Pt,
     pub line_height: u32,
@@ -60,6 +62,7 @@ impl Cursor {
 /// - Increasing Y moves downward on the screen, increasing X moves right
 /// - (WIDTH, LINES) is bottom right
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
 pub struct ClipRect {
     pub min: Pt,
     pub max: Pt,
@@ -93,6 +96,7 @@ impl ClipRect {
 
 /// Style options for Latin script fonts
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[repr(C)]
 pub enum GlyphStyle {
     Small = 0,
     Regular = 1,


### PR DESCRIPTION
This replaces externally-visible `usize` properties and arguments with `u32` variants, to keep structures identical across platforms.