### PR TITLE
Clip insertion point at last row of framebuffer

### DIFF
--- a/src/blit.rs
+++ b/src/blit.rs
@@ -41,7 +41,12 @@ fn draw_ins(fb: &mut FrBuf, c: &Cursor) {
     // draw an insertion pointer that's a couple pixels short either side of the line height
     let y = (c.pt.y + 2) as usize;
     let x = c.pt.x as usize;
-    let height = (c.pt.y + c.line_height - 2) as usize;
+    let mut height = (c.pt.y + c.line_height - 2) as usize;
+    let fb_rows = fb.len() / WORDS_PER_LINE;
+    if height >= fb_rows {
+        // Truncate height to avoid attempting to draw beyond last line of framebuffer
+        height = fb_rows - 1;
+    }
     for row in y..height {
         fb[((x + row * WORDS_PER_LINE * 32) / 32) as usize] ^= (1 << (x % 32));
         // set the dirty bit on the line that contains the pixel


### PR DESCRIPTION
This should fix an array index out of bounds panic that was happening when typing very long shellchat commands. The problem was that the y coordinate calculations for drawing an insertion point did not do a bounds check against the height of the destination frame buffer: https://github.com/betrusted-io/blitstr/blob/cebcabb9a2b0686bb47f6e1508640941ae88469c/src/blit.rs#L40-L50

To reproduce the panic, typing this string should be sufficient: "abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz0123456789abcdefghijklmnopqrstuvwxyz012345".

The problem seems to happen when shellchat input wraps from 12 rows high to 13 rows high.

Notes:
1. This change only prevents the array index out of bounds panic related to drawing the insertion point. There appear to be other drawing glitches with very long shellchat input strings.
2. Preparing this PR involved some sneaky git tricks because we intentionally left samblenny/blitstr/main 21 commits behind betrusted-io/blistr/main. So, this is a PR coming *from a non-main branch on the upstream* to main of a fork. The semblenny/blitstr/danger-fork branch is effectively a downstream fork of betrusted-io/blitstr/main. GitHub won't let me actually fork the forked repo because I already own the upstream, so this is the next best thing. But, it's a bit unusual and confusing. I think this should probably merge okay?